### PR TITLE
Issue 185 - Update arrow to default over listItems on About page

### DIFF
--- a/frontend/src/components/About.js
+++ b/frontend/src/components/About.js
@@ -30,6 +30,7 @@ const About = () => {
       padding: '10px',
       boxShadow: '0 2px 5px rgba(0, 0, 0, 0.1)',
       transition: 'background-color 0.3s, box-shadow 0.3s',
+      cursor: 'default'
     },
   };
 


### PR DESCRIPTION
Cursow now set to default over listItems on the About page. Resolves issue #185 

https://github.com/Rajat2024/NoteBook/assets/65582950/d4947db9-b1ea-402d-a918-e8154c940bee

